### PR TITLE
feat: Implement backend interaction mode switching (Issue #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,14 @@ Ambi is an AI-powered conversational companion designed to reduce loneliness and
     ```
 2.  **Set up Backend Environment:**
     *   Navigate to the backend directory: `cd backend`
-    *   Copy the example environment file: `cp .env.example .env`
-    *   **Edit `backend/.env`**: Fill in *all* required API keys and connection strings (MongoDB, Redis, Anthropic, ElevenLabs, Deepgram). Refer to `backend/.env.example` for variable names.
+    *   Create a `.env` file for your environment variables. You can copy the example:
+        ```bash
+        cp .env.example .env
+        ```
+    *   **Edit `backend/.env`**: Fill in *all* required API keys and connection strings (Redis, Anthropic, ElevenLabs, Deepgram, Pinecone, etc.). Refer to `backend/.env.example` for the full list of required variables.
+    *   **Configure Interaction Mode**: The `INTERACTION_MODE` variable in `.env` controls the primary interaction method:
+        *   `INTERACTION_MODE=voice` (Default): Uses speech-to-text (Deepgram) and text-to-speech (ElevenLabs). Requires relevant API keys.
+        *   `INTERACTION_MODE=text`: Disables voice input/output, relying only on text. Useful for development or if voice services are unavailable.
 3.  **Install Backend Dependencies:**
     *   While in the `backend` directory:
         ```bash
@@ -124,9 +130,16 @@ This script will:
 
 ### Required Environment Variables
 
-The memory system requires the following environment variables:
+The backend requires several environment variables for API keys and service connections. Please refer to the `backend/.env.example` file for a complete list and descriptions.
 
-- `REDIS_URL`: Connection URL for Redis
-- `PINECONE_API_KEY`: API key for Pinecone
-- `PINECONE_INDEX_NAME`: Name of the Pinecone index
-- `OPENAI_API_KEY`: API key for OpenAI (used for embeddings)
+Key variables include:
+- `NODE_ENV`: Set to `development`, `production`, or `test`.
+- `PORT`: The port the backend server runs on.
+- `INTERACTION_MODE`: Controls voice/text interaction (see Setup section).
+- `REDIS_URL`: Connection URL for Redis (short-term memory).
+- `PINECONE_API_KEY`: API key for Pinecone (long-term memory).
+- `PINECONE_INDEX_NAME`: Name of the Pinecone index.
+- `ANTHROPIC_API_KEY`: API key for Claude (core LLM).
+- `DEEPGRAM_API_KEY`: API key for Deepgram (speech-to-text).
+- `ELEVENLABS_API_KEY`: API key for ElevenLabs (text-to-speech).
+- `OPENAI_API_KEY`: API key for OpenAI (used for embeddings).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,16 @@
 # Backend Environment Variables
 
-# Server Port
+# General
+NODE_ENV=development # development | production | test
 PORT=4000
 
+# Interaction Mode (voice | text)
+# Determines if the backend primarily uses voice (Deepgram/ElevenLabs) or text interfaces.
+# Defaults to 'voice' if not set.
+INTERACTION_MODE=voice
+
 # MongoDB Connection String (replace with your actual URI)
-MONGODB_URI=mongodb://localhost:27017/ambi_dev
+MONGODB_URI=
 
 # Redis Connection URL (replace with your actual URI, including credentials)
 # Format: redis://[<user>][:<password>@]<host>[:<port>]

--- a/backend/src/__tests__/conversation.test.ts
+++ b/backend/src/__tests__/conversation.test.ts
@@ -4,26 +4,53 @@ import { redisClient } from '../clients/redisClient'; // Import redisClient for 
 import app from '../index'; // Import the exported Express app
 import { getClaudeResponse } from '../clients/claudeClient';
 import { addToMemory, getRecentHistory } from '../services/memoryManager';
+import { voiceService } from '../services/voiceService'; // Import voiceService
 
 // Mock the external dependencies
 jest.mock('../clients/claudeClient');
 jest.mock('../services/memoryManager');
+jest.mock('../services/voiceService', () => ({
+  voiceService: {
+    textToSpeech: {
+      synthesize: jest.fn(),
+    },
+    // Mock other parts if needed by other tests
+    speechToText: {
+      transcribe: jest.fn(),
+      setupLiveTranscription: jest.fn(),
+    }
+  }
+}));
 
 // Define mock types for stricter type checking in mocks
-const mockGetClaudeResponse = getClaudeResponse as jest.MockedFunction<typeof getClaudeResponse>; 
+const mockGetClaudeResponse = getClaudeResponse as jest.MockedFunction<typeof getClaudeResponse>;
 const mockAddToMemory = addToMemory as jest.MockedFunction<typeof addToMemory>;
 const mockGetRecentHistory = getRecentHistory as jest.MockedFunction<typeof getRecentHistory>;
+// Create a typed mock for the synthesize function
+const mockSynthesize = voiceService.textToSpeech.synthesize as jest.Mock;
 
 describe('POST /api/conversation', () => {
+  const originalEnv = process.env; // Store original environment variables
+
   beforeEach(() => {
     // Reset mocks before each test
     mockGetClaudeResponse.mockClear();
     mockAddToMemory.mockClear();
     mockGetRecentHistory.mockClear();
+    mockSynthesize.mockClear(); // Clear synthesize mock
 
     // Default mock implementations
     mockGetRecentHistory.mockResolvedValue([]); // Return empty history by default
     mockGetClaudeResponse.mockResolvedValue('Mocked Claude response.'); // Return a simple string
+    mockSynthesize.mockResolvedValue(Buffer.from('mock audio data')); // Default successful synthesis
+    
+    // Reset environment variables to avoid test pollution
+    process.env = { ...originalEnv }; 
+  });
+
+  afterEach(() => {
+    // Restore original environment variables after each test
+    process.env = originalEnv;
   });
 
   it('should return 200 and AI reply on valid request', async () => {
@@ -79,6 +106,62 @@ describe('POST /api/conversation', () => {
     // We may not get a predictable body, so commenting out body check
     // expect(response.body).toEqual({ error: 'Internal Server Error' }); // Or similar
     expect(mockAddToMemory).not.toHaveBeenCalled();
+  });
+
+  it('should synthesize audio in voice mode', async () => {
+    process.env['INTERACTION_MODE'] = 'voice';
+    const userMessage = 'Hello in voice mode';
+    const mockReply = 'Mocked voice reply.';
+    const mockAudio = Buffer.from('mock voice audio');
+    mockGetClaudeResponse.mockResolvedValueOnce(mockReply);
+    mockSynthesize.mockResolvedValueOnce(mockAudio);
+
+    const response = await request(app)
+      .post('/api/conversation')
+      .send({ message: userMessage });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('reply', mockReply);
+    expect(response.body).toHaveProperty('audioReply', mockAudio.toString('base64'));
+    expect(mockSynthesize).toHaveBeenCalledTimes(1);
+    expect(mockSynthesize).toHaveBeenCalledWith(mockReply);
+    expect(mockAddToMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not synthesize audio in text mode', async () => {
+    process.env['INTERACTION_MODE'] = 'text';
+    const userMessage = 'Hello in text mode';
+    const mockReply = 'Mocked text reply.';
+    mockGetClaudeResponse.mockResolvedValueOnce(mockReply);
+
+    const response = await request(app)
+      .post('/api/conversation')
+      .send({ message: userMessage });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('reply', mockReply);
+    expect(response.body).toHaveProperty('audioReply', null);
+    expect(mockSynthesize).not.toHaveBeenCalled();
+    expect(mockAddToMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle synthesis failure in voice mode', async () => {
+    process.env['INTERACTION_MODE'] = 'voice';
+    const userMessage = 'Trigger synthesis error';
+    const mockReply = 'Mocked reply for synthesis failure.';
+    mockGetClaudeResponse.mockResolvedValueOnce(mockReply);
+    mockSynthesize.mockResolvedValueOnce(null); // Simulate synthesis failure
+
+    const response = await request(app)
+      .post('/api/conversation')
+      .send({ message: userMessage });
+
+    expect(response.status).toBe(200); // Should still succeed with text reply
+    expect(response.body).toHaveProperty('reply', mockReply);
+    expect(response.body).toHaveProperty('audioReply', null);
+    expect(mockSynthesize).toHaveBeenCalledTimes(1);
+    expect(mockSynthesize).toHaveBeenCalledWith(mockReply);
+    expect(mockAddToMemory).toHaveBeenCalledTimes(1);
   });
 
   // Add more tests: e.g., missing message body (should be handled by express.json typically or validation)

--- a/backend/src/__tests__/voiceConversation.test.ts
+++ b/backend/src/__tests__/voiceConversation.test.ts
@@ -26,7 +26,13 @@ const mockAddToMemory = addToMemory as jest.MockedFunction<typeof addToMemory>;
 const mockGetRecentHistory = getRecentHistory as jest.MockedFunction<typeof getRecentHistory>;
 
 describe('POST /api/voice-conversation', () => {
+  const originalEnv = process.env; // Store original environment
+
   beforeEach(() => {
+    // Reset Environment Variables
+    process.env = { ...originalEnv }; 
+    process.env.INTERACTION_MODE = 'voice'; // Ensure voice mode for this suite
+    
     mockSpeechToText.mockClear();
     mockTextToSpeech.mockClear();
     mockGetClaudeResponse.mockClear();
@@ -37,6 +43,11 @@ describe('POST /api/voice-conversation', () => {
     mockSpeechToText.mockResolvedValue('Transcribed text');
     mockGetClaudeResponse.mockResolvedValue('Mocked Claude response.');
     mockTextToSpeech.mockResolvedValue(Buffer.from('Mocked audio data'));
+  });
+
+  afterEach(() => {
+    // Restore original environment variables after each test
+    process.env = originalEnv;
   });
 
   it('should process voice input and return audio and text responses', async () => {
@@ -153,6 +164,8 @@ describe('POST /api/voice-conversation', () => {
   });
 
   afterAll(async () => {
+    // Restore original environment variables after the suite is done
+    process.env = originalEnv; 
     try {
       await mongoose.disconnect();
       


### PR DESCRIPTION
Closes #21

## Summary

This PR implements the backend portion of Issue #21, introducing an `INTERACTION_MODE` environment variable to allow switching between 'voice' and 'text' interaction modes. This enables configuring the application to use either full voice capabilities or operate in a text-only manner, useful for development or environments without voice service credentials.

## Changes Implemented

*   **Environment Variable:** Introduced `INTERACTION_MODE` (`voice` or `text`, defaults to `voice`) read via `dotenv`.
*   **/api/conversation Endpoint:**
    *   Conditionally synthesizes voice using `voiceService` only when `INTERACTION_MODE` is 'voice'.
    *   Adds an `audioReply` field (base64 audio string or null) to the response payload.
*   **/api/voice-conversation Endpoint:**
    *   Now checks `INTERACTION_MODE` and returns a 400 error if called when the mode is not 'voice'.
*   **Refactoring:** Moved the reading of `INTERACTION_MODE` from the module scope into the specific route handlers (`/api/conversation`, `/api/voice-conversation`) in `backend/src/index.ts` to ensure correct behavior in tests.
*   **Testing:** Added new tests to `backend/src/__tests__/conversation.test.ts` to verify the conditional voice synthesis and response structure based on `INTERACTION_MODE`.
*   **Documentation:** Updated `README.md` to explain the `INTERACTION_MODE` variable and guide users to configure it in their `.env` file (referencing `backend/.env.example`).

## Related Fixes

*   Addressed test failures encountered after reverting the `main` branch, which were caused by out-of-sync `node_modules` and incorrect test environment variable simulation. A clean install (`rm -rf node_modules && npm install`) and the refactoring of `index.ts` resolved these issues.
*   All backend tests now pass.
